### PR TITLE
[KEEP-73] Variable timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const asclepius = require('asclepius');
 const nullLogger = require('null-logger');
 
-const sequelizeHealthcheck = (sequelize, logger = nullLogger) => asclepius.healthcheck(
+const defaultTimeout = 500;
+
+const sequelizeHealthcheck = (sequelize, logger = nullLogger, timeout = defaultTimeout) => asclepius.healthcheck(
   'psql',
   () =>
     sequelize
@@ -11,10 +13,10 @@ const sequelizeHealthcheck = (sequelize, logger = nullLogger) => asclepius.healt
         logger.error('PSQL Healthcheck Failed. Reason:', err);
         return Promise.reject(err.name);
       }),
-  500
+  timeout
 );
 
-const redisHealthcheck = (redis, logger = nullLogger) => asclepius.healthcheck(
+const redisHealthcheck = (redis, logger = nullLogger, timeout = defaultTimeout) => asclepius.healthcheck(
   'redis',
   () =>
     new Promise((resolve, reject) => {
@@ -26,10 +28,10 @@ const redisHealthcheck = (redis, logger = nullLogger) => asclepius.healthcheck(
         return resolve();
       });
     }),
-  500
+  timeout
 );
 
-const elasticsearchHealthcheck = (elasticsearch, logger = nullLogger) => asclepius.healthcheck(
+const elasticsearchHealthcheck = (elasticsearch, logger = nullLogger, timeout = defaultTimeout) => asclepius.healthcheck(
   'elasticsearch',
   () =>
     elasticsearch
@@ -39,22 +41,32 @@ const elasticsearchHealthcheck = (elasticsearch, logger = nullLogger) => asclepi
         logger.error('Elasticsearch Healthcheck Failed. Reason:', err);
         return Promise.reject('Ping Failed');
       }),
-  500
+  timeout
 );
 
 const processHealthcheck = asclepius.healthcheck(
   'process',
   () => Promise.resolve(),
-  500
+  defaultTimeout
 );
 
-module.exports = {
-  setup: ({ sequelize = null, redis = null, elasticsearch = null, logger = nullLogger } = {}) => {
+const _buildHealthCheckArray = ({ sequelize = null, redis = null, elasticsearch = null, logger = nullLogger, timeout = defaultTimeout } = {}) => {
     const healthchecks = [processHealthcheck];
 
-    if (sequelize) healthchecks.push(sequelizeHealthcheck(sequelize, logger));
-    if (elasticsearch) healthchecks.push(elasticsearchHealthcheck(elasticsearch, logger));
-    if (redis) healthchecks.push(redisHealthcheck(redis, logger));
+    if (sequelize) healthchecks.push(sequelizeHealthcheck(sequelize, logger, timeout));
+    if (elasticsearch) healthchecks.push(elasticsearchHealthcheck(elasticsearch, logger, timeout));
+    if (redis) healthchecks.push(redisHealthcheck(redis, logger, timeout));
+
+    return healthchecks;
+}
+
+module.exports = {
+  setup: ({ sequelize = null, redis = null, elasticsearch = null, logger = nullLogger, timeout = defaultTimeout } = {}) => {
+    const healthchecks = _buildHealthCheckArray({ sequelize, redis, elasticsearch, logger, timeout });
     return asclepius.makeRoute(healthchecks);
+  },
+  runner: ({ sequelize = null, redis = null, elasticsearch = null, logger = nullLogger, timeout = defaultTimeout } = {}) => {
+    const healthchecks = _buildHealthCheckArray({ sequelize, redis, elasticsearch, logger, timeout });
+    return asclepius.makeRunner(healthchecks);
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asclepius-standard",
-  "version": "1.0.2",
+  "version": "1.1.0-alpha.0",
   "description": "Asclepius Standard Configuration",
   "repository": "git@github.com:ordermentum/asclepius-standard.git",
   "main": "index.js",


### PR DESCRIPTION
This adds two things:
* a way to override the default timeout of 500ms
* a new function to return a health check runner rather than just an express endpoint (for use with non-HTTP services)
